### PR TITLE
use pretty permalinks

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -35,9 +35,10 @@ header_pages:
   - en/about.markdown
   - en/events.markdown
 
+# same as /:categories/:year/:month/:day/:title/
+permalink: pretty
 collections:
   posts:
-    permalink: /:categories/:title
 future: true
 
 defaults:


### PR DESCRIPTION
In order to ensure url's are unique for each event, we want to also use the `/:year/:month/:day` based on the file name, and enabling permalink pretty does all that by default, as well as the categories. See https://devhints.io/jekyll

and it also hides extentions, so no more `/en/events.html` now it's just `/en/events`