### PR TITLE
Check for header_text front matter, otherwise use page title for head…

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ i18n_key: about
 ```
 
 ## Add a page to header
-Inside each of the page front matters make sure they have a title
+Inside each of the page front matters make sure they have a title or header_text
 ```markdown
 # en/about.markdown
 title: "About"

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -19,8 +19,8 @@
         <div class="trigger">
           {%- for path in page_paths -%}
             {%- assign my_page = site.pages | where: "path", path | first -%}
-            {%- if my_page.title -%}
-              <a class="page-link" href="{{ my_page.url | relative_url }}">{{ my_page.title | escape }}</a>
+            {%- if my_page.header_text || my_page.title -%}
+              <a class="page-link" href="{{ my_page.url | relative_url }}">{{ my_page.header_text || my_page.title | escape }}</a>
             {%- endif -%}
           {%- endfor -%}
           <a class="page-link" href="https://github.com/codecurious-bln/CC-website/edit/master/{{ page.path }}" target="_blank">Edit on GitHub</a>

--- a/en/about.markdown
+++ b/en/about.markdown
@@ -1,6 +1,7 @@
 ---
 layout: page
 title: What is code curious?
+header_text: About
 i18n_key: about
 ---
 


### PR DESCRIPTION
Now header_links can optionally have different text from the page.title

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] README Update

## Added to documentation?

- [x] README
- [ ] no documentation needed

## Screenshots
**Before this PR:** 
<img width="955" alt="Screenshot 2019-11-07 at 15 32 00" src="https://user-images.githubusercontent.com/7111514/68397774-ffa39980-0173-11ea-869d-e86df50125b1.png">

**After this PR:** 

<img width="801" alt="Screenshot 2019-11-07 at 15 34 49" src="https://user-images.githubusercontent.com/7111514/68397865-22ce4900-0174-11ea-8571-fb14a13b4fda.png">


## [optional] What gif best describes this PR or how it makes you feel?
 